### PR TITLE
remove pin on requests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "python-dateutil",
     "pandas>=2.0.0",
     "numpy>=1.24.0",
-    "requests<2.32.0",  
+    "requests",  
     "requests-mock"
 ]
 


### PR DESCRIPTION
# Pull Request

## Description

This PR removes the version pin for the `requests` library (i.e., `"requests<2.32.0"`). The goal is to allow the package to use the latest version of `requests` instead of restricting it to versions below 2.32.0. This is done to keep the project's dependencies up to date, ensuring security patches and new features from newer releases are incorporated.

Fixes #53 

## How Has This Been Tested?

The following steps were performed to verify the changes:
- Removed the version constraint on `requests`.
- Installed the latest version of `requests`.
- Ran the full test suite to ensure there were no breaking changes or regressions caused by the version update.
  
Sanity checks were also performed to confirm that API requests continue to function as expected.

- [x] Yes, the changes were tested by running the automated test suite.

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if necessary)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
