### PR TITLE
Update api_client.py

### DIFF
--- a/elexonpy/api/reference_api.py
+++ b/elexonpy/api/reference_api.py
@@ -68,7 +68,7 @@ class ReferenceApi(object):
                  returns the request thread.
         """
 
-        all_params = []  # noqa: E501
+        all_params = ['format']  # noqa: E501
         all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')

--- a/elexonpy/api/reference_api.py
+++ b/elexonpy/api/reference_api.py
@@ -68,7 +68,7 @@ class ReferenceApi(object):
                  returns the request thread.
         """
 
-        all_params = ['format']  # noqa: E501
+        all_params = []  # noqa: E501
         all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
@@ -89,8 +89,6 @@ class ReferenceApi(object):
         path_params = {}
 
         query_params = []
-        if 'format' in params:
-            query_params.append(('format', params['format']))  # noqa: E501
 
         header_params = {}
 

--- a/elexonpy/api/reference_api.py
+++ b/elexonpy/api/reference_api.py
@@ -89,6 +89,8 @@ class ReferenceApi(object):
         path_params = {}
 
         query_params = []
+        if 'format' in params:
+            query_params.append(('format', params['format']))  # noqa: E501
 
         header_params = {}
 

--- a/elexonpy/api_client.py
+++ b/elexonpy/api_client.py
@@ -123,8 +123,8 @@ class ApiClient(object):
                 )
 
         # query parameters
+        change_to_dataframe, query_params = self.format_to_dataframe(query_params)
         if query_params:
-            change_to_dataframe, query_params = self.format_to_dataframe(query_params)
             query_params = self.sanitize_for_serialization(query_params)
             query_params = self.parameters_to_tuples(query_params,
                                                      collection_formats)


### PR DESCRIPTION
# Pull Request

## Description
Fixes #64

Move the assignment outside the ```if``` statement to ensure ```change_to_dataframe``` is assigned even if ```query_params``` is empty.

Passing an empty list into the method ```self.format_to_dataframe(query_params)``` is fine.


## How Has This Been Tested?
```
import elexonpy.api as elex
unit_data = elex.ReferenceApi().reference_bmunits_all_get()

# test endpoint with non-empty query_params
df = elex.DemandApi().demand_outturn_get(settlement_date_from='2025-09-01', settlement_date_to='2025-09-19', format='dataframe')
```
- [ - ] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_
Doesn't affect data processing
- [ ] Yes

## Checklist:

- [- ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [- ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [- ] I have checked my code and corrected any misspellings
